### PR TITLE
SP-357 [go-catapult-sdk] Namespace.GetNamespacesFromAccounts throws error on valid arguments

### DIFF
--- a/sdk/account_internal.go
+++ b/sdk/account_internal.go
@@ -175,11 +175,13 @@ func (dto multisigAccountGraphInfoDTOS) toStruct(networkType NetworkType) (*Mult
 	return &MultisigAccountGraphInfo{ms}, nil
 }
 
-type addresses []*Address
+type addresses struct {
+	Addresses []*Address
+}
 
 func (ref *addresses) MarshalJSON() (buf []byte, err error) {
 	buf = []byte(`{"addresses":[`)
-	for i, address := range *ref {
+	for i, address := range ref.Addresses {
 		b := []byte(`"` + address.Address + `"`)
 		if i > 0 {
 			buf = append(buf, ',')

--- a/sdk/namespace.go
+++ b/sdk/namespace.go
@@ -108,7 +108,7 @@ func (ref *NamespaceService) GetNamespacesFromAccounts(ctx context.Context, addr
 
 	dtos := namespaceInfoDTOs(make([]*namespaceInfoDTO, 0))
 
-	resp, err := ref.client.DoNewRequest(ctx, http.MethodPost, url.Encode(), addresses(addrs), &dtos)
+	resp, err := ref.client.DoNewRequest(ctx, http.MethodPost, url.Encode(), &addresses{addrs}, &dtos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Started use marshaler of addresses